### PR TITLE
Fix "File exists" error on startup

### DIFF
--- a/root/etc/cont-init.d/20-directories
+++ b/root/etc/cont-init.d/20-directories
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv sh
-mkdir /data
+mkdir -p /data
 mkdir -p /run/postgresql
 mkdir -p /run/nginx
 mkdir -p /var/log/funkwhale


### PR DESCRIPTION
When booting the container, an `mkdir: can't create directory '/data': File exists` error is printed to the logs. Irritatingly, nothing gets printed after this error for a while since the chown/chmod calls may take a while to complete, so the user may get the impression the container failed to start up.
