### PR TITLE
Remove chmod and chown on startup (fixes #30)

### DIFF
--- a/root/etc/cont-init.d/20-directories
+++ b/root/etc/cont-init.d/20-directories
@@ -4,19 +4,3 @@ mkdir -p /run/postgresql
 mkdir -p /run/nginx
 mkdir -p /var/log/funkwhale
 mkdir -p /app/api/staticfiles
-
-# ownership
-chown -R funkwhale:funkwhale /app
-chown -R funkwhale:funkwhale /data
-chown -R funkwhale:funkwhale /var/log/funkwhale
-chown -R funkwhale:funkwhale /run/postgresql
-
-# permission
-chmod -R 0700 /app
-chmod -R 0750 /app/api/staticfiles
-chmod -R 0750 /app/front
-chmod 0750 /app
-chmod 0750 /app/api
-
-chmod -R 0755 /var/log/funkwhale
-chmod -R 0755 /data


### PR DESCRIPTION
This is taking like an hour on each restart for my instance, and it doesnt even do anything. If the permissions are wrong, Funkwhale should already show an error about it so that it can be fixed manually. Doing this on each start is just not useful.